### PR TITLE
edge case test 추가

### DIFF
--- a/src/test/java/com/swapandgo/sag/domain/ItemTest.java
+++ b/src/test/java/com/swapandgo/sag/domain/ItemTest.java
@@ -86,6 +86,10 @@ public class ItemTest {
         LocalDateTime start = LocalDateTime.now();
         LocalDateTime end = start.plusDays(1);
         assertThat(item.addTradeOffer(requester, start, end)).isNotNull();
+
+        assertThatThrownBy(() -> item.addTradeOffer(requester, start, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("대여 기간");
     }
 
     @Test
@@ -152,5 +156,83 @@ public class ItemTest {
         assertThatThrownBy(item::completed)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("이미 완료");
+    }
+
+    @Test
+    void validate_throwsWhenTitleBlank() {
+        User user = User.createUser("u", "u@test.com", "pw", null);
+        Item item = Item.create(
+                user, " ", "c", new BigDecimal("10.00"),
+                null, ItemType.RESALE, TradeType.SELL, Category.전자기기, "Seoul", List.of()
+        );
+
+        assertThatThrownBy(item::validate)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("제목");
+    }
+
+    @Test
+    void validate_throwsWhenContentBlank() {
+        User user = User.createUser("u", "u@test.com", "pw", null);
+        Item item = Item.create(
+                user, "t", " ", new BigDecimal("10.00"),
+                null, ItemType.RESALE, TradeType.SELL, Category.전자기기, "Seoul", List.of()
+        );
+
+        assertThatThrownBy(item::validate)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("본문");
+    }
+
+    @Test
+    void validate_throwsWhenPriceZero() {
+        User user = User.createUser("u", "u@test.com", "pw", null);
+        Item item = Item.create(
+                user, "t", "c", BigDecimal.ZERO,
+                null, ItemType.RESALE, TradeType.SELL, Category.전자기기, "Seoul", List.of()
+        );
+
+        assertThatThrownBy(item::validate)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("가격");
+    }
+
+    @Test
+    void validate_throwsWhenPriceNegative() {
+        User user = User.createUser("u", "u@test.com", "pw", null);
+        Item item = Item.create(
+                user, "t", "c", new BigDecimal("-1.00"),
+                null, ItemType.RESALE, TradeType.SELL, Category.전자기기, "Seoul", List.of()
+        );
+
+        assertThatThrownBy(item::validate)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("가격");
+    }
+
+    @Test
+    void validate_rentalRequiresDeposit() {
+        User user = User.createUser("u", "u@test.com", "pw", null);
+        Item item = Item.create(
+                user, "t", "c", new BigDecimal("10.00"),
+                null, ItemType.RENTAL, TradeType.SELL, Category.전자기기, "Seoul", List.of()
+        );
+
+        assertThatThrownBy(item::validate)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("보증금");
+    }
+
+    @Test
+    void validate_rentalRequiresPositiveDeposit() {
+        User user = User.createUser("u", "u@test.com", "pw", null);
+        Item item = Item.create(
+                user, "t", "c", new BigDecimal("10.00"),
+                BigDecimal.ZERO, ItemType.RENTAL, TradeType.SELL, Category.전자기기, "Seoul", List.of()
+        );
+
+        assertThatThrownBy(item::validate)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("보증금");
     }
 }

--- a/src/test/java/com/swapandgo/sag/domain/TradeOfferTest.java
+++ b/src/test/java/com/swapandgo/sag/domain/TradeOfferTest.java
@@ -70,4 +70,21 @@ public class TradeOfferTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("진행 중인 요청");
     }
+
+    @Test
+    void create_allowsSameStartAndEnd() {
+        User requester = User.createUser("r", "r@test.com", "pw", null);
+        Item item = Item.create(
+                User.createUser("o", "o@test.com", "pw", null),
+                "t", "c", new BigDecimal("10.00"), new BigDecimal("5.00"),
+                ItemType.RENTAL, TradeType.SELL, Category.스포츠, "Seoul", List.of()
+        );
+
+        LocalDateTime at = LocalDateTime.now();
+        TradeOffer offer = TradeOffer.create(requester, item, at, at);
+
+        assertThat(offer.getStartAt()).isEqualTo(at);
+        assertThat(offer.getEndAt()).isEqualTo(at);
+        assertThat(offer.getStatus()).isEqualTo(TradeOfferStatus.PENDING);
+    }
 }

--- a/src/test/java/com/swapandgo/sag/domain/UserTest.java
+++ b/src/test/java/com/swapandgo/sag/domain/UserTest.java
@@ -40,4 +40,13 @@ public class UserTest {
         assertThat(user.getWishLists()).hasSize(1);
         assertThat(user.getWishLists().get(0).getItem()).isEqualTo(item);
     }
+
+    @Test
+    void updateProfile_nullAddress_overwritesToNull() {
+        User user = User.createUser("u", "u@test.com", "pw", new Address("KR", "Seoul", "street"));
+
+        user.updateProfile(null, null, null);
+
+        assertThat(user.getAddress()).isNull();
+    }
 }


### PR DESCRIPTION
Item.validate() 경계값
•제목 공백 → 예외
•내용 공백 → 예외
•가격 0 → 예외
•가격 음수 → 예외
•대여 + 보증금 null → 예외
•대여 + 보증금 0 → 예외
TradeOffer 기간 경계
•startAt == endAt 허용 여부 테스트
•endAt < startAt 예외 (기존)
•대여 요청에서 startAt만 있고 endAt 없음 → 예외
Item.completed() 상태 경계
•이미 COMPLETED/RENTED 상태에서 재호출 → 예외
•deposit=null vs deposit>0에 따라 상태 분기
Item.getThumbnailUrl() 빈 데이터
•이미지 없음 → null
•main 이미지 없음 → 첫 번째 이미지 반환
User.updateProfile() 부분 업데이트
•username만 변경 시 password 유지
•address=null이면 null로 덮어쓰기(현 구현 기준으로 고정)