### PR TITLE
Refactor: 거래요청/조기반납 API를 RESTful하게 변경

### DIFF
--- a/src/main/java/com/swapandgo/sag/api/tradeoffer/TradeOfferController.java
+++ b/src/main/java/com/swapandgo/sag/api/tradeoffer/TradeOfferController.java
@@ -1,7 +1,9 @@
 package com.swapandgo.sag.api.tradeoffer;
 
+import com.swapandgo.sag.domain.tradeoffer.TradeOfferStatus;
 import com.swapandgo.sag.dto.tradeoffer.TradeOfferCreateRequest;
 import com.swapandgo.sag.dto.tradeoffer.TradeOfferResponse;
+import com.swapandgo.sag.dto.tradeoffer.TradeOfferStatusUpdateRequest;
 import com.swapandgo.sag.security.user.CustomUserDetails;
 import com.swapandgo.sag.service.tradeoffer.TradeOfferAcceptResult;
 import com.swapandgo.sag.service.tradeoffer.TradeOfferService;
@@ -10,10 +12,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -24,7 +27,7 @@ import java.util.stream.Collectors;
 public class TradeOfferController {
     private final TradeOfferService tradeOfferService;
 
-    @PostMapping("/api/tradeoffer")
+    @PostMapping("/api/tradeoffers")
     public ResponseEntity<TradeOfferResponse> createTradeOffer(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid TradeOfferCreateRequest request) {
@@ -35,55 +38,50 @@ public class TradeOfferController {
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/api/tradeoffer/{tradeOfferId}")
-    public ResponseEntity<TradeOfferResponse> cancelTradeOffer(
+    @PatchMapping("/api/tradeoffers/{tradeOfferId}")
+    public ResponseEntity<TradeOfferResponse> updateTradeOfferStatus(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long tradeOfferId) {
+            @PathVariable Long tradeOfferId,
+            @RequestBody @Valid TradeOfferStatusUpdateRequest request) {
         Long userId = userDetails.getUserId();
-        TradeOfferResponse response = new TradeOfferResponse(
-                tradeOfferService.cancelOffer(userId, tradeOfferId)
-        );
-        return ResponseEntity.ok(response);
+        TradeOfferStatus status = request.getStatus();
+        if (status == TradeOfferStatus.CANCELED) {
+            TradeOfferResponse response = new TradeOfferResponse(
+                    tradeOfferService.cancelOffer(userId, tradeOfferId)
+            );
+            return ResponseEntity.ok(response);
+        }
+        if (status == TradeOfferStatus.ACCEPTED) {
+            TradeOfferAcceptResult result = tradeOfferService.acceptOffer(userId, tradeOfferId);
+            TradeOfferResponse response = new TradeOfferResponse(result.getTradeOffer(), result.getTransactionId());
+            return ResponseEntity.ok(response);
+        }
+        if (status == TradeOfferStatus.REJECTED) {
+            TradeOfferResponse response = new TradeOfferResponse(
+                    tradeOfferService.rejectOffer(userId, tradeOfferId)
+            );
+            return ResponseEntity.ok(response);
+        }
+        throw new IllegalArgumentException("지원하지 않는 상태 변경입니다.");
     }
 
-    @PostMapping("/api/tradeoffer/{tradeOfferId}/accept")
-    public ResponseEntity<TradeOfferResponse> acceptTradeOffer(
+    @GetMapping("/api/tradeoffers")
+    public ResponseEntity<List<TradeOfferResponse>> listTradeOffers(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long tradeOfferId) {
+            @RequestParam("role") String role) {
         Long userId = userDetails.getUserId();
-        TradeOfferAcceptResult result = tradeOfferService.acceptOffer(userId, tradeOfferId);
-        TradeOfferResponse response = new TradeOfferResponse(result.getTradeOffer(), result.getTransactionId());
-        return ResponseEntity.ok(response);
-    }
-
-    @PostMapping("/api/tradeoffer/{tradeOfferId}/reject")
-    public ResponseEntity<TradeOfferResponse> rejectTradeOffer(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long tradeOfferId) {
-        Long userId = userDetails.getUserId();
-        TradeOfferResponse response = new TradeOfferResponse(
-                tradeOfferService.rejectOffer(userId, tradeOfferId)
-        );
-        return ResponseEntity.ok(response);
-    }
-
-    @GetMapping("/api/tradeoffer/sent")
-    public ResponseEntity<List<TradeOfferResponse>> getSentTradeOffers(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long userId = userDetails.getUserId();
-        List<TradeOfferResponse> responses = tradeOfferService.listSentOffers(userId).stream()
-                .map(TradeOfferResponse::new)
-                .collect(Collectors.toList());
-        return ResponseEntity.ok(responses);
-    }
-
-    @GetMapping("/api/tradeoffer/received")
-    public ResponseEntity<List<TradeOfferResponse>> getReceivedTradeOffers(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long userId = userDetails.getUserId();
-        List<TradeOfferResponse> responses = tradeOfferService.listReceivedOffers(userId).stream()
-                .map(TradeOfferResponse::new)
-                .collect(Collectors.toList());
+        List<TradeOfferResponse> responses;
+        if ("sender".equalsIgnoreCase(role)) {
+            responses = tradeOfferService.listSentOffers(userId).stream()
+                    .map(TradeOfferResponse::new)
+                    .collect(Collectors.toList());
+        } else if ("receiver".equalsIgnoreCase(role)) {
+            responses = tradeOfferService.listReceivedOffers(userId).stream()
+                    .map(TradeOfferResponse::new)
+                    .collect(Collectors.toList());
+        } else {
+            throw new IllegalArgumentException("role은 sender 또는 receiver 여야 합니다.");
+        }
         return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/swapandgo/sag/api/transaction/TransactionController.java
+++ b/src/main/java/com/swapandgo/sag/api/transaction/TransactionController.java
@@ -2,6 +2,7 @@ package com.swapandgo.sag.api.transaction;
 
 import com.swapandgo.sag.dto.transaction.EarlyReturnRequest;
 import com.swapandgo.sag.dto.transaction.EarlyReturnResponse;
+import com.swapandgo.sag.dto.transaction.EarlyReturnStatusUpdateRequest;
 import com.swapandgo.sag.dto.transaction.TransactionResponse;
 import com.swapandgo.sag.security.user.CustomUserDetails;
 import com.swapandgo.sag.service.transaction.TransactionService;
@@ -10,8 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,35 +37,14 @@ public class TransactionController {
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/api/transactions/{transactionId}/early-return")
-    public ResponseEntity<EarlyReturnResponse> cancelEarlyReturn(
+    @PatchMapping("/api/transactions/{transactionId}/early-return")
+    public ResponseEntity<EarlyReturnResponse> updateEarlyReturnStatus(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long transactionId) {
+            @PathVariable Long transactionId,
+            @RequestBody @Valid EarlyReturnStatusUpdateRequest request) {
         Long userId = userDetails.getUserId();
         EarlyReturnResponse response = new EarlyReturnResponse(
-                transactionService.cancelEarlyReturn(userId, transactionId)
-        );
-        return ResponseEntity.ok(response);
-    }
-
-    @PostMapping("/api/transactions/{transactionId}/early-return/accept")
-    public ResponseEntity<EarlyReturnResponse> acceptEarlyReturn(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long transactionId) {
-        Long userId = userDetails.getUserId();
-        EarlyReturnResponse response = new EarlyReturnResponse(
-                transactionService.acceptEarlyReturn(userId, transactionId)
-        );
-        return ResponseEntity.ok(response);
-    }
-
-    @PostMapping("/api/transactions/{transactionId}/early-return/reject")
-    public ResponseEntity<EarlyReturnResponse> rejectEarlyReturn(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long transactionId) {
-        Long userId = userDetails.getUserId();
-        EarlyReturnResponse response = new EarlyReturnResponse(
-                transactionService.rejectEarlyReturn(userId, transactionId)
+                transactionService.updateEarlyReturnStatus(userId, transactionId, request.getStatus())
         );
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/swapandgo/sag/dto/tradeoffer/TradeOfferStatusUpdateRequest.java
+++ b/src/main/java/com/swapandgo/sag/dto/tradeoffer/TradeOfferStatusUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.swapandgo.sag.dto.tradeoffer;
+
+import com.swapandgo.sag.domain.tradeoffer.TradeOfferStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TradeOfferStatusUpdateRequest {
+    @NotNull
+    private TradeOfferStatus status;
+}

--- a/src/main/java/com/swapandgo/sag/dto/transaction/EarlyReturnStatusUpdateRequest.java
+++ b/src/main/java/com/swapandgo/sag/dto/transaction/EarlyReturnStatusUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.swapandgo.sag.dto.transaction;
+
+import com.swapandgo.sag.domain.transaction.EarlyReturnStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EarlyReturnStatusUpdateRequest {
+    @NotNull
+    private EarlyReturnStatus status;
+}

--- a/src/main/java/com/swapandgo/sag/service/transaction/TransactionService.java
+++ b/src/main/java/com/swapandgo/sag/service/transaction/TransactionService.java
@@ -1,6 +1,7 @@
 package com.swapandgo.sag.service.transaction;
 
 import com.swapandgo.sag.domain.item.Item;
+import com.swapandgo.sag.domain.transaction.EarlyReturnStatus;
 import com.swapandgo.sag.domain.transaction.Transaction;
 import com.swapandgo.sag.dto.transaction.EarlyReturnRequest;
 import com.swapandgo.sag.repository.TransactionRepository;
@@ -60,6 +61,19 @@ public class TransactionService {
 
         transaction.rejectEarlyReturn(LocalDateTime.now());
         return transaction;
+    }
+
+    public Transaction updateEarlyReturnStatus(Long ownerId, Long transactionId, EarlyReturnStatus status) {
+        if (status == EarlyReturnStatus.ACCEPTED) {
+            return acceptEarlyReturn(ownerId, transactionId);
+        }
+        if (status == EarlyReturnStatus.REJECTED) {
+            return rejectEarlyReturn(ownerId, transactionId);
+        }
+        if (status == EarlyReturnStatus.CANCELED) {
+            return cancelEarlyReturn(ownerId, transactionId);
+        }
+        throw new IllegalArgumentException("지원하지 않는 상태 변경입니다.");
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 변경 사항
  - 거래요청 API를 RESTful하게 변경
    - /api/tradeoffers (POST)
    - /api/tradeoffers/{id} (PATCH: ACCEPTED/REJECTED/CANCELED)
    - /api/tradeoffers?role=sender|receiver (GET)
  - 조기반납 API도 PATCH로 통일
    - /api/transactions/{id}/early-return (PATCH: ACCEPTED/REJECTED/CANCELED)
    - DELETE 제거

  ## 호환성 주의
  - 기존 /accept, /reject, /sent, /received 엔드포인트는 제거됨

  ## 테스트
  - 포스트맨으로 tradeoffers 생성/상태변경/조회 확인
  - 포스트맨으로 early-return 상태변경 확인
