### PR TITLE
Feat: 채팅 기능 추가 (방 생성/목록/메시지 조회·전송/웹소켓 실시간 양방향 통신)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'com.sendgrid:sendgrid-java:4.10.2'

--- a/chat-test.html
+++ b/chat-test.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chat WS Test</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    .row { margin-bottom: 10px; }
+    input, button { padding: 6px 8px; }
+    #log { white-space: pre-wrap; border: 1px solid #ccc; padding: 10px; height: 240px; overflow: auto; }
+  </style>
+</head>
+<body>
+  <h1>Chat WebSocket Test</h1>
+
+  <div class="row">
+    <label>Access Token</label>
+    <input id="token" style="width: 70%" placeholder="Bearer 없이 토큰만" />
+  </div>
+  <div class="row">
+    <label>Room ID</label>
+    <input id="roomId" value="10" />
+  </div>
+  <div class="row">
+    <button id="connectBtn">Connect</button>
+    <button id="subscribeBtn">Subscribe</button>
+    <button id="disconnectBtn">Disconnect</button>
+  </div>
+  <div class="row">
+    <input id="message" style="width: 70%" placeholder="message" />
+    <button id="sendBtn">Send</button>
+  </div>
+
+  <h3>Log</h3>
+  <div id="log"></div>
+
+  <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@7/dist/stomp.min.js"></script>
+  <script>
+    let client = null;
+    let subscription = null;
+
+    const logEl = document.getElementById('log');
+    const tokenEl = document.getElementById('token');
+    const roomIdEl = document.getElementById('roomId');
+    const messageEl = document.getElementById('message');
+
+    function log(msg) {
+      const now = new Date().toISOString();
+      logEl.textContent += `[${now}] ${msg}\n`;
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    document.getElementById('connectBtn').onclick = () => {
+      if (client && client.connected) {
+        log('Already connected');
+        return;
+      }
+      const sock = new SockJS('http://localhost:8080/ws/chat-sockjs');
+      client = new StompJs.Client({
+        webSocketFactory: () => sock,
+        reconnectDelay: 0,
+        connectHeaders: {
+          Authorization: 'Bearer ' + tokenEl.value.trim()
+        },
+        onConnect: () => {
+          log('Connected');
+        },
+        onStompError: (frame) => {
+          log('STOMP error: ' + frame.headers['message']);
+        },
+        onWebSocketError: (err) => {
+          log('WS error: ' + err);
+        },
+        debug: (str) => {
+          // log(str);
+        }
+      });
+      client.activate();
+      log('Connecting...');
+    };
+
+    document.getElementById('subscribeBtn').onclick = () => {
+      if (!client || !client.connected) {
+        log('Not connected');
+        return;
+      }
+      const roomId = roomIdEl.value.trim();
+      if (!roomId) {
+        log('Room ID required');
+        return;
+      }
+      if (subscription) {
+        subscription.unsubscribe();
+        subscription = null;
+      }
+      const dest = `/sub/chat/rooms/${roomId}`;
+      subscription = client.subscribe(dest, (message) => {
+        log('Received: ' + message.body);
+      });
+      log('Subscribed to ' + dest);
+    };
+
+    document.getElementById('sendBtn').onclick = () => {
+      if (!client || !client.connected) {
+        log('Not connected');
+        return;
+      }
+      const roomId = roomIdEl.value.trim();
+      const content = messageEl.value;
+      if (!roomId || !content) {
+        log('Room ID and message required');
+        return;
+      }
+      client.publish({
+        destination: '/pub/chat/send',
+        body: JSON.stringify({ roomId: Number(roomId), content })
+      });
+      log('Sent: ' + content);
+      messageEl.value = '';
+    };
+
+    document.getElementById('disconnectBtn').onclick = () => {
+      if (subscription) {
+        subscription.unsubscribe();
+        subscription = null;
+      }
+      if (client) {
+        client.deactivate();
+        client = null;
+        log('Disconnected');
+      }
+    };
+  </script>
+</body>
+</html>

--- a/src/main/java/com/swapandgo/sag/api/chat/ChatController.java
+++ b/src/main/java/com/swapandgo/sag/api/chat/ChatController.java
@@ -1,0 +1,70 @@
+package com.swapandgo.sag.api.chat;
+
+import com.swapandgo.sag.dto.chat.ChatMessageResponse;
+import com.swapandgo.sag.dto.chat.ChatMessageSendRequest;
+import com.swapandgo.sag.dto.chat.ChatRoomCreateRequest;
+import com.swapandgo.sag.dto.chat.ChatRoomResponse;
+import com.swapandgo.sag.security.user.CustomUserDetails;
+import com.swapandgo.sag.service.chat.ChatService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+public class ChatController {
+    private final ChatService chatService;
+
+    @PostMapping("/api/chat/rooms")
+    public ResponseEntity<ChatRoomResponse> createRoom(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid ChatRoomCreateRequest request) {
+        Long userId = userDetails.getUserId();
+        ChatRoomResponse response = new ChatRoomResponse(
+                chatService.createOrGetRoom(request.getItemId(), userId)
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/api/chat/rooms")
+    public ResponseEntity<List<ChatRoomResponse>> listMyRooms(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        List<ChatRoomResponse> responses = chatService.listMyRooms(userId).stream()
+                .map(ChatRoomResponse::new)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/api/chat/rooms/{roomId}/messages")
+    public ResponseEntity<List<ChatMessageResponse>> listMessages(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long roomId) {
+        Long userId = userDetails.getUserId();
+        List<ChatMessageResponse> responses = chatService.listMessages(roomId, userId).stream()
+                .map(ChatMessageResponse::new)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responses);
+    }
+
+    @PostMapping("/api/chat/rooms/{roomId}/messages")
+    public ResponseEntity<ChatMessageResponse> sendMessage(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long roomId,
+            @RequestBody @Valid ChatMessageSendRequest request) {
+        Long userId = userDetails.getUserId();
+        // Path와 body roomId 일치 검증
+        if (!roomId.equals(request.getRoomId())) {
+            throw new IllegalArgumentException("roomId가 일치하지 않습니다.");
+        }
+        ChatMessageResponse response = new ChatMessageResponse(
+                chatService.sendMessage(userId, request)
+        );
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/swapandgo/sag/api/chat/ChatController.java
+++ b/src/main/java/com/swapandgo/sag/api/chat/ChatController.java
@@ -13,7 +13,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,9 +34,7 @@ public class ChatController {
     public ResponseEntity<List<ChatRoomResponse>> listMyRooms(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails.getUserId();
-        List<ChatRoomResponse> responses = chatService.listMyRooms(userId).stream()
-                .map(ChatRoomResponse::new)
-                .collect(Collectors.toList());
+        List<ChatRoomResponse> responses = chatService.listMyRoomResponses(userId);
         return ResponseEntity.ok(responses);
     }
 
@@ -48,7 +45,7 @@ public class ChatController {
         Long userId = userDetails.getUserId();
         List<ChatMessageResponse> responses = chatService.listMessages(roomId, userId).stream()
                 .map(ChatMessageResponse::new)
-                .collect(Collectors.toList());
+                .toList();
         return ResponseEntity.ok(responses);
     }
 

--- a/src/main/java/com/swapandgo/sag/api/chat/ChatWebSocketController.java
+++ b/src/main/java/com/swapandgo/sag/api/chat/ChatWebSocketController.java
@@ -1,0 +1,31 @@
+package com.swapandgo.sag.api.chat;
+
+import com.swapandgo.sag.dto.chat.ChatMessageResponse;
+import com.swapandgo.sag.dto.chat.ChatMessageSendRequest;
+import com.swapandgo.sag.security.user.CustomUserDetails;
+import com.swapandgo.sag.service.chat.ChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatWebSocketController {
+    private final ChatService chatService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/chat/send")
+    public void sendMessage(ChatMessageSendRequest request, Authentication authentication) {
+        if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails userDetails)) {
+            throw new SecurityException("인증이 필요합니다.");
+        }
+        Long userId = userDetails.getUserId();
+        ChatMessageResponse response = new ChatMessageResponse(
+                chatService.sendMessage(userId, request)
+        );
+        String destination = "/sub/chat/rooms/" + request.getRoomId();
+        messagingTemplate.convertAndSend(destination, response);
+    }
+}

--- a/src/main/java/com/swapandgo/sag/api/tradeoffer/TradeOfferController.java
+++ b/src/main/java/com/swapandgo/sag/api/tradeoffer/TradeOfferController.java
@@ -1,5 +1,6 @@
 package com.swapandgo.sag.api.tradeoffer;
 
+import com.swapandgo.sag.domain.item.ItemType;
 import com.swapandgo.sag.domain.tradeoffer.TradeOfferStatus;
 import com.swapandgo.sag.dto.tradeoffer.TradeOfferCreateRequest;
 import com.swapandgo.sag.dto.tradeoffer.TradeOfferResponse;
@@ -27,13 +28,24 @@ import java.util.stream.Collectors;
 public class TradeOfferController {
     private final TradeOfferService tradeOfferService;
 
-    @PostMapping("/api/tradeoffers")
-    public ResponseEntity<TradeOfferResponse> createTradeOffer(
+    @PostMapping("/api/tradeoffers/resale")
+    public ResponseEntity<TradeOfferResponse> createResaleTradeOffer(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid TradeOfferCreateRequest request) {
         Long userId = userDetails.getUserId();
         TradeOfferResponse response = new TradeOfferResponse(
-                tradeOfferService.createOffer(userId, request)
+                tradeOfferService.createOffer(userId, request, ItemType.RESALE)
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/api/tradeoffers/rental")
+    public ResponseEntity<TradeOfferResponse> createRentalTradeOffer(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid TradeOfferCreateRequest request) {
+        Long userId = userDetails.getUserId();
+        TradeOfferResponse response = new TradeOfferResponse(
+                tradeOfferService.createOffer(userId, request, ItemType.RENTAL)
         );
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/swapandgo/sag/api/transaction/TransactionController.java
+++ b/src/main/java/com/swapandgo/sag/api/transaction/TransactionController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -53,9 +52,7 @@ public class TransactionController {
     public ResponseEntity<List<TransactionResponse>> getBuyerTransactions(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails.getUserId();
-        List<TransactionResponse> responses = transactionService.listBuyerTransactions(userId).stream()
-                .map(TransactionResponse::new)
-                .collect(Collectors.toList());
+        List<TransactionResponse> responses = transactionService.listBuyerTransactionResponses(userId);
         return ResponseEntity.ok(responses);
     }
 
@@ -63,9 +60,7 @@ public class TransactionController {
     public ResponseEntity<List<TransactionResponse>> getSellerTransactions(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails.getUserId();
-        List<TransactionResponse> responses = transactionService.listSellerTransactions(userId).stream()
-                .map(TransactionResponse::new)
-                .collect(Collectors.toList());
+        List<TransactionResponse> responses = transactionService.listSellerTransactionResponses(userId);
         return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/swapandgo/sag/config/WebConfig.java
+++ b/src/main/java/com/swapandgo/sag/config/WebConfig.java
@@ -16,6 +16,7 @@ public class WebConfig {
                 registry.addMapping("/**")
                         .allowedOriginPatterns(
                                 "http://localhost:3000",
+                                "http://localhost:8000",
                                 "https://*.ngrok.app",
                                 "https://swap-go-git-develop-diwonis-projects.vercel.app"
                         )

--- a/src/main/java/com/swapandgo/sag/config/WebSocketConfig.java
+++ b/src/main/java/com/swapandgo/sag/config/WebSocketConfig.java
@@ -1,0 +1,52 @@
+package com.swapandgo.sag.config;
+
+import com.swapandgo.sag.security.jwt.JwtTokenProvider;
+import com.swapandgo.sag.security.user.CustomUserDetailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailService userDetailsService;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub");
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws/chat")
+                .setAllowedOriginPatterns(
+                        "http://localhost:3000",
+                        "http://localhost:8000",
+                        "https://*.ngrok.app",
+                        "https://*.ngrok-free.dev",
+                        "https://swap-go-git-develop-diwonis-projects.vercel.app"
+                );
+
+        registry.addEndpoint("/ws/chat-sockjs")
+                .setAllowedOriginPatterns(
+                        "http://localhost:3000",
+                        "http://localhost:8000",
+                        "https://*.ngrok.app",
+                        "https://*.ngrok-free.dev",
+                        "https://swap-go-git-develop-diwonis-projects.vercel.app"
+                )
+                .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(new WebSocketStompAuthInterceptor(jwtTokenProvider, userDetailsService));
+    }
+}

--- a/src/main/java/com/swapandgo/sag/config/WebSocketStompAuthInterceptor.java
+++ b/src/main/java/com/swapandgo/sag/config/WebSocketStompAuthInterceptor.java
@@ -1,0 +1,50 @@
+package com.swapandgo.sag.config;
+
+import com.swapandgo.sag.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.util.StringUtils;
+
+@RequiredArgsConstructor
+public class WebSocketStompAuthInterceptor implements ChannelInterceptor {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+            String bearer = accessor.getFirstNativeHeader("Authorization");
+            String token = parseBearer(bearer);
+            if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+                String email = jwtTokenProvider.getEmailFromToken(token);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                accessor.setUser(authentication);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+        return message;
+    }
+
+    private String parseBearer(String bearer) {
+        if (!StringUtils.hasText(bearer)) {
+            return null;
+        }
+        String[] parts = bearer.trim().split("\\s+");
+        if (parts.length == 2 && parts[0].equalsIgnoreCase("Bearer")) {
+            return parts[1].trim();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/swapandgo/sag/domain/chat/ChatMessage.java
+++ b/src/main/java/com/swapandgo/sag/domain/chat/ChatMessage.java
@@ -36,11 +36,16 @@ public class ChatMessage {
 
     //생성 메서드
     public static ChatMessage text(ChatRoom room, User sender, String content) {
+        return create(room, sender, content, null);
+    }
+
+    public static ChatMessage create(ChatRoom room, User sender, String content, String url) {
         ChatMessage m = new ChatMessage();
         m.sender = sender;
         m.content = content;
+        m.url = url;
         m.createdAt = LocalDateTime.now();
-        room.addMessage(m); // ★ 여기서 연관관계 세팅 + 컬렉션 추가
+        room.addMessage(m);
         m.validateSendable();
         return m;
     }

--- a/src/main/java/com/swapandgo/sag/domain/chat/ChatRoom.java
+++ b/src/main/java/com/swapandgo/sag/domain/chat/ChatRoom.java
@@ -4,7 +4,6 @@ import com.swapandgo.sag.domain.item.Item;
 import com.swapandgo.sag.domain.user.User;
 import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -34,6 +33,18 @@ public class ChatRoom {
 
     private LocalDateTime createdAt;
 
+    public static ChatRoom create(Item item, User buyer, User seller) {
+        if (item == null || buyer == null || seller == null) {
+            throw new IllegalArgumentException("item/buyer/seller는 필수입니다.");
+        }
+        ChatRoom room = new ChatRoom();
+        room.item = item;
+        room.buyer = buyer;
+        room.seller = seller;
+        room.createdAt = LocalDateTime.now();
+        return room;
+    }
+
     public void addMessage(ChatMessage m) {
         if (!messages.contains(m)) {
             messages.add(m);
@@ -42,8 +53,11 @@ public class ChatRoom {
     }
 
     public boolean isParticipant(User user) {
-        return user != null && (user.equals(seller) || user.equals(buyer));
+        if (user == null) return false;
+        Long userId = user.getId();
+        return userId != null
+                && ((seller != null && userId.equals(seller.getId()))
+                || (buyer != null && userId.equals(buyer.getId())));
     }
-
 
 }

--- a/src/main/java/com/swapandgo/sag/dto/chat/ChatMessageResponse.java
+++ b/src/main/java/com/swapandgo/sag/dto/chat/ChatMessageResponse.java
@@ -10,6 +10,7 @@ public class ChatMessageResponse {
     private final Long messageId;
     private final Long roomId;
     private final Long senderId;
+    private final String senderName;
     private final String content;
     private final String url;
     private final LocalDateTime createdAt;
@@ -18,6 +19,7 @@ public class ChatMessageResponse {
         this.messageId = message.getId();
         this.roomId = message.getChatRoom().getId();
         this.senderId = message.getSender().getId();
+        this.senderName = message.getSender().getUsername();
         this.content = message.getContent();
         this.url = message.getUrl();
         this.createdAt = message.getCreatedAt();

--- a/src/main/java/com/swapandgo/sag/dto/chat/ChatMessageResponse.java
+++ b/src/main/java/com/swapandgo/sag/dto/chat/ChatMessageResponse.java
@@ -1,0 +1,25 @@
+package com.swapandgo.sag.dto.chat;
+
+import com.swapandgo.sag.domain.chat.ChatMessage;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ChatMessageResponse {
+    private final Long messageId;
+    private final Long roomId;
+    private final Long senderId;
+    private final String content;
+    private final String url;
+    private final LocalDateTime createdAt;
+
+    public ChatMessageResponse(ChatMessage message) {
+        this.messageId = message.getId();
+        this.roomId = message.getChatRoom().getId();
+        this.senderId = message.getSender().getId();
+        this.content = message.getContent();
+        this.url = message.getUrl();
+        this.createdAt = message.getCreatedAt();
+    }
+}

--- a/src/main/java/com/swapandgo/sag/dto/chat/ChatMessageSendRequest.java
+++ b/src/main/java/com/swapandgo/sag/dto/chat/ChatMessageSendRequest.java
@@ -1,0 +1,15 @@
+package com.swapandgo.sag.dto.chat;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChatMessageSendRequest {
+    @NotNull
+    private Long roomId;
+
+    private String content;
+    private String url;
+}

--- a/src/main/java/com/swapandgo/sag/dto/chat/ChatRoomCreateRequest.java
+++ b/src/main/java/com/swapandgo/sag/dto/chat/ChatRoomCreateRequest.java
@@ -1,0 +1,12 @@
+package com.swapandgo.sag.dto.chat;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChatRoomCreateRequest {
+    @NotNull
+    private Long itemId;
+}

--- a/src/main/java/com/swapandgo/sag/dto/chat/ChatRoomResponse.java
+++ b/src/main/java/com/swapandgo/sag/dto/chat/ChatRoomResponse.java
@@ -1,0 +1,23 @@
+package com.swapandgo.sag.dto.chat;
+
+import com.swapandgo.sag.domain.chat.ChatRoom;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ChatRoomResponse {
+    private final Long roomId;
+    private final Long itemId;
+    private final Long buyerId;
+    private final Long sellerId;
+    private final LocalDateTime createdAt;
+
+    public ChatRoomResponse(ChatRoom room) {
+        this.roomId = room.getId();
+        this.itemId = room.getItem().getId();
+        this.buyerId = room.getBuyer().getId();
+        this.sellerId = room.getSeller().getId();
+        this.createdAt = room.getCreatedAt();
+    }
+}

--- a/src/main/java/com/swapandgo/sag/dto/chat/ChatRoomResponse.java
+++ b/src/main/java/com/swapandgo/sag/dto/chat/ChatRoomResponse.java
@@ -9,15 +9,41 @@ import java.time.LocalDateTime;
 public class ChatRoomResponse {
     private final Long roomId;
     private final Long itemId;
+    private final String itemTitle;
+    private final String itemThumbnailUrl;
     private final Long buyerId;
+    private final String buyerName;
     private final Long sellerId;
+    private final String sellerName;
+    private final String lastMessage;
+    private final LocalDateTime lastMessageAt;
     private final LocalDateTime createdAt;
 
     public ChatRoomResponse(ChatRoom room) {
         this.roomId = room.getId();
         this.itemId = room.getItem().getId();
+        this.itemTitle = room.getItem().getTitle();
+        this.itemThumbnailUrl = room.getItem().getThumbnailUrl();
         this.buyerId = room.getBuyer().getId();
+        this.buyerName = room.getBuyer().getUsername();
         this.sellerId = room.getSeller().getId();
+        this.sellerName = room.getSeller().getUsername();
+        this.lastMessage = null;
+        this.lastMessageAt = null;
+        this.createdAt = room.getCreatedAt();
+    }
+
+    public ChatRoomResponse(ChatRoom room, String lastMessage, LocalDateTime lastMessageAt) {
+        this.roomId = room.getId();
+        this.itemId = room.getItem().getId();
+        this.itemTitle = room.getItem().getTitle();
+        this.itemThumbnailUrl = room.getItem().getThumbnailUrl();
+        this.buyerId = room.getBuyer().getId();
+        this.buyerName = room.getBuyer().getUsername();
+        this.sellerId = room.getSeller().getId();
+        this.sellerName = room.getSeller().getUsername();
+        this.lastMessage = lastMessage;
+        this.lastMessageAt = lastMessageAt;
         this.createdAt = room.getCreatedAt();
     }
 }

--- a/src/main/java/com/swapandgo/sag/dto/tradeoffer/TradeOfferResponse.java
+++ b/src/main/java/com/swapandgo/sag/dto/tradeoffer/TradeOfferResponse.java
@@ -2,6 +2,7 @@ package com.swapandgo.sag.dto.tradeoffer;
 
 import com.swapandgo.sag.domain.tradeoffer.TradeOffer;
 import com.swapandgo.sag.domain.tradeoffer.TradeOfferStatus;
+import com.swapandgo.sag.domain.item.ItemType;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 
@@ -12,7 +13,12 @@ import java.time.LocalDateTime;
         "tradeOfferId",
         "transactionId",
         "itemId",
+        "itemType",
+        "itemTitle",
         "requesterId",
+        "requesterName",
+        "ownerId",
+        "ownerName",
         "status",
         "createdAt",
         "startAt",
@@ -22,7 +28,12 @@ public class TradeOfferResponse {
     private final Long tradeOfferId;
     private final Long transactionId;
     private final Long itemId;
+    private final ItemType itemType;
+    private final String itemTitle;
     private final Long requesterId;
+    private final String requesterName;
+    private final Long ownerId;
+    private final String ownerName;
     private final TradeOfferStatus status;
     private final LocalDateTime createdAt;
     private final LocalDateTime startAt;
@@ -32,7 +43,12 @@ public class TradeOfferResponse {
         this.tradeOfferId = tradeOffer.getId();
         this.transactionId = null;
         this.itemId = tradeOffer.getItem().getId();
+        this.itemType = tradeOffer.getItem().getType();
+        this.itemTitle = tradeOffer.getItem().getTitle();
         this.requesterId = tradeOffer.getRequester().getId();
+        this.requesterName = tradeOffer.getRequester().getUsername();
+        this.ownerId = tradeOffer.getItem().getUser().getId();
+        this.ownerName = tradeOffer.getItem().getUser().getUsername();
         this.status = tradeOffer.getStatus();
         this.createdAt = tradeOffer.getCreatedAt();
         this.startAt = tradeOffer.getStartAt();
@@ -43,7 +59,12 @@ public class TradeOfferResponse {
         this.tradeOfferId = tradeOffer.getId();
         this.transactionId = transactionId;
         this.itemId = tradeOffer.getItem().getId();
+        this.itemType = tradeOffer.getItem().getType();
+        this.itemTitle = tradeOffer.getItem().getTitle();
         this.requesterId = tradeOffer.getRequester().getId();
+        this.requesterName = tradeOffer.getRequester().getUsername();
+        this.ownerId = tradeOffer.getItem().getUser().getId();
+        this.ownerName = tradeOffer.getItem().getUser().getUsername();
         this.status = tradeOffer.getStatus();
         this.createdAt = tradeOffer.getCreatedAt();
         this.startAt = tradeOffer.getStartAt();

--- a/src/main/java/com/swapandgo/sag/dto/transaction/TransactionResponse.java
+++ b/src/main/java/com/swapandgo/sag/dto/transaction/TransactionResponse.java
@@ -1,6 +1,7 @@
 package com.swapandgo.sag.dto.transaction;
 
 import com.swapandgo.sag.domain.item.ItemType;
+import com.swapandgo.sag.domain.item.ItemStatus;
 import com.swapandgo.sag.domain.transaction.EarlyReturnStatus;
 import com.swapandgo.sag.domain.transaction.Transaction;
 import lombok.Getter;
@@ -11,9 +12,17 @@ import java.time.LocalDateTime;
 public class TransactionResponse {
     private final Long transactionId;
     private final Long itemId;
+    private final String itemTitle;
+    private final String itemThumbnailUrl;
+    private final java.math.BigDecimal itemPrice;
+    private final String itemLocation;
+    private final Boolean isLiked;
     private final Long buyerId;
+    private final String buyerName;
     private final Long sellerId;
+    private final String sellerName;
     private final ItemType itemType;
+    private final ItemStatus itemStatus;
     private final LocalDateTime startAt;
     private final LocalDateTime endAt;
     private final EarlyReturnStatus earlyReturnStatus;
@@ -22,9 +31,37 @@ public class TransactionResponse {
     public TransactionResponse(Transaction transaction) {
         this.transactionId = transaction.getId();
         this.itemId = transaction.getItem().getId();
+        this.itemTitle = transaction.getItem().getTitle();
+        this.itemThumbnailUrl = transaction.getItem().getThumbnailUrl();
+        this.itemPrice = transaction.getItem().getPrice();
+        this.itemLocation = transaction.getItem().getLocation();
+        this.isLiked = null;
         this.buyerId = transaction.getBuyer().getId();
+        this.buyerName = transaction.getBuyer().getUsername();
         this.sellerId = transaction.getItem().getUser().getId();
+        this.sellerName = transaction.getItem().getUser().getUsername();
         this.itemType = transaction.getType();
+        this.itemStatus = transaction.getItem().getStatus();
+        this.startAt = transaction.getStartAt();
+        this.endAt = transaction.getEndAt();
+        this.earlyReturnStatus = transaction.getEarlyReturnStatus();
+        this.createdAt = transaction.getCreatedAt();
+    }
+
+    public TransactionResponse(Transaction transaction, boolean isLiked) {
+        this.transactionId = transaction.getId();
+        this.itemId = transaction.getItem().getId();
+        this.itemTitle = transaction.getItem().getTitle();
+        this.itemThumbnailUrl = transaction.getItem().getThumbnailUrl();
+        this.itemPrice = transaction.getItem().getPrice();
+        this.itemLocation = transaction.getItem().getLocation();
+        this.isLiked = isLiked;
+        this.buyerId = transaction.getBuyer().getId();
+        this.buyerName = transaction.getBuyer().getUsername();
+        this.sellerId = transaction.getItem().getUser().getId();
+        this.sellerName = transaction.getItem().getUser().getUsername();
+        this.itemType = transaction.getType();
+        this.itemStatus = transaction.getItem().getStatus();
         this.startAt = transaction.getStartAt();
         this.endAt = transaction.getEndAt();
         this.earlyReturnStatus = transaction.getEarlyReturnStatus();

--- a/src/main/java/com/swapandgo/sag/repository/ChatMessageRepository.java
+++ b/src/main/java/com/swapandgo/sag/repository/ChatMessageRepository.java
@@ -4,7 +4,9 @@ import com.swapandgo.sag.domain.chat.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
     List<ChatMessage> findAllByChatRoomIdOrderByIdAsc(Long chatRoomId);
+    Optional<ChatMessage> findTopByChatRoomIdOrderByIdDesc(Long chatRoomId);
 }

--- a/src/main/java/com/swapandgo/sag/repository/ChatMessageRepository.java
+++ b/src/main/java/com/swapandgo/sag/repository/ChatMessageRepository.java
@@ -1,0 +1,10 @@
+package com.swapandgo.sag.repository;
+
+import com.swapandgo.sag.domain.chat.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    List<ChatMessage> findAllByChatRoomIdOrderByIdAsc(Long chatRoomId);
+}

--- a/src/main/java/com/swapandgo/sag/repository/ChatRoomRepository.java
+++ b/src/main/java/com/swapandgo/sag/repository/ChatRoomRepository.java
@@ -1,0 +1,13 @@
+package com.swapandgo.sag.repository;
+
+import com.swapandgo.sag.domain.chat.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+    Optional<ChatRoom> findByItemIdAndBuyerId(Long itemId, Long buyerId);
+
+    List<ChatRoom> findAllByBuyerIdOrSellerIdOrderByIdDesc(Long buyerId, Long sellerId);
+}

--- a/src/main/java/com/swapandgo/sag/security/SecurityConfig.java
+++ b/src/main/java/com/swapandgo/sag/security/SecurityConfig.java
@@ -94,7 +94,8 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        .requestMatchers("/error").permitAll()
+                        .requestMatchers("/error", "/favicon.ico", "/chat-test.html").permitAll()
+                        .requestMatchers("/ws/**").permitAll()
                         .requestMatchers(
                                 "/api/auth/**",
                                 "/api/resale/items/**",

--- a/src/main/java/com/swapandgo/sag/service/chat/ChatService.java
+++ b/src/main/java/com/swapandgo/sag/service/chat/ChatService.java
@@ -5,6 +5,7 @@ import com.swapandgo.sag.domain.chat.ChatRoom;
 import com.swapandgo.sag.domain.item.Item;
 import com.swapandgo.sag.domain.user.User;
 import com.swapandgo.sag.dto.chat.ChatMessageSendRequest;
+import com.swapandgo.sag.dto.chat.ChatRoomResponse;
 import com.swapandgo.sag.repository.ChatMessageRepository;
 import com.swapandgo.sag.repository.ChatRoomRepository;
 import com.swapandgo.sag.repository.ItemRepository;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -43,6 +45,26 @@ public class ChatService {
     @Transactional(readOnly = true)
     public List<ChatRoom> listMyRooms(Long userId) {
         return chatRoomRepository.findAllByBuyerIdOrSellerIdOrderByIdDesc(userId, userId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatRoomResponse> listMyRoomResponses(Long userId) {
+        List<ChatRoom> rooms = listMyRooms(userId);
+        return rooms.stream()
+                .map(room -> {
+                    ChatMessage lastMessage = chatMessageRepository
+                            .findTopByChatRoomIdOrderByIdDesc(room.getId())
+                            .orElse(null);
+                    if (lastMessage == null) {
+                        return new ChatRoomResponse(room);
+                    }
+                    String content = lastMessage.getContent();
+                    if ((content == null || content.isBlank()) && lastMessage.getUrl() != null) {
+                        content = "[첨부]";
+                    }
+                    return new ChatRoomResponse(room, content, lastMessage.getCreatedAt());
+                })
+                .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/swapandgo/sag/service/chat/ChatService.java
+++ b/src/main/java/com/swapandgo/sag/service/chat/ChatService.java
@@ -1,0 +1,71 @@
+package com.swapandgo.sag.service.chat;
+
+import com.swapandgo.sag.domain.chat.ChatMessage;
+import com.swapandgo.sag.domain.chat.ChatRoom;
+import com.swapandgo.sag.domain.item.Item;
+import com.swapandgo.sag.domain.user.User;
+import com.swapandgo.sag.dto.chat.ChatMessageSendRequest;
+import com.swapandgo.sag.repository.ChatMessageRepository;
+import com.swapandgo.sag.repository.ChatRoomRepository;
+import com.swapandgo.sag.repository.ItemRepository;
+import com.swapandgo.sag.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatService {
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ItemRepository itemRepository;
+    private final UserRepository userRepository;
+
+    public ChatRoom createOrGetRoom(Long itemId, Long requesterId) {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new EntityNotFoundException("Item not found: " + itemId));
+        User buyer = userRepository.findById(requesterId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found: " + requesterId));
+        User seller = item.getUser();
+
+        if (seller.getId().equals(buyer.getId())) {
+            throw new IllegalArgumentException("본인 상품에는 채팅을 생성할 수 없습니다.");
+        }
+
+        return chatRoomRepository.findByItemIdAndBuyerId(itemId, buyer.getId())
+                .orElseGet(() -> chatRoomRepository.save(ChatRoom.create(item, buyer, seller)));
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatRoom> listMyRooms(Long userId) {
+        return chatRoomRepository.findAllByBuyerIdOrSellerIdOrderByIdDesc(userId, userId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatMessage> listMessages(Long roomId, Long userId) {
+        ChatRoom room = findRoom(roomId);
+        User user = userRepository.getReferenceById(userId);
+        if (!room.isParticipant(user)) {
+            throw new SecurityException("채팅방 접근 권한이 없습니다.");
+        }
+        return chatMessageRepository.findAllByChatRoomIdOrderByIdAsc(roomId);
+    }
+
+    public ChatMessage sendMessage(Long userId, ChatMessageSendRequest request) {
+        ChatRoom room = findRoom(request.getRoomId());
+        User sender = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found: " + userId));
+
+        ChatMessage message = ChatMessage.create(room, sender, request.getContent(), request.getUrl());
+        return chatMessageRepository.save(message);
+    }
+
+    public ChatRoom findRoom(Long roomId) {
+        return chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new EntityNotFoundException("ChatRoom not found: " + roomId));
+    }
+}

--- a/src/main/java/com/swapandgo/sag/service/tradeoffer/TradeOfferService.java
+++ b/src/main/java/com/swapandgo/sag/service/tradeoffer/TradeOfferService.java
@@ -29,11 +29,15 @@ public class TradeOfferService {
     private final UserRepository userRepository;
     private final TransactionRepository transactionRepository;
 
-    public TradeOffer createOffer(Long requesterId, TradeOfferCreateRequest request) {
+    public TradeOffer createOffer(Long requesterId, TradeOfferCreateRequest request, ItemType expectedType) {
         User requester = userRepository.findById(requesterId)
                 .orElseThrow(() -> new EntityNotFoundException("User not found: " + requesterId));
         Item item = itemRepository.findById(request.getItemId())
                 .orElseThrow(() -> new EntityNotFoundException("Item not found: " + request.getItemId()));
+
+        if (expectedType != null && item.getType() != expectedType) {
+            throw new IllegalArgumentException("요청 타입이 아이템 타입과 일치하지 않습니다.");
+        }
 
         if (item.getStatus() != ItemStatus.ACTIVE) {
             throw new IllegalStateException("비활성화된 게시글에는 요청을 보낼 수 없습니다.");

--- a/src/main/java/com/swapandgo/sag/service/transaction/TransactionService.java
+++ b/src/main/java/com/swapandgo/sag/service/transaction/TransactionService.java
@@ -4,8 +4,10 @@ import com.swapandgo.sag.domain.item.Item;
 import com.swapandgo.sag.domain.transaction.EarlyReturnStatus;
 import com.swapandgo.sag.domain.transaction.Transaction;
 import com.swapandgo.sag.dto.transaction.EarlyReturnRequest;
+import com.swapandgo.sag.dto.transaction.TransactionResponse;
 import com.swapandgo.sag.repository.TransactionRepository;
 import com.swapandgo.sag.repository.UserRepository;
+import com.swapandgo.sag.repository.WishListRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +24,7 @@ import java.util.List;
 public class TransactionService {
     private final TransactionRepository transactionRepository;
     private final UserRepository userRepository;
+    private final WishListRepository wishListRepository;
 
     public Transaction requestEarlyReturn(Long requesterId, Long transactionId, EarlyReturnRequest request) {
         Transaction transaction = findTransaction(transactionId);
@@ -86,8 +91,37 @@ public class TransactionService {
         return transactionRepository.findAllByItemUserIdOrderByIdDesc(sellerId);
     }
 
+    @Transactional(readOnly = true)
+    public List<TransactionResponse> listBuyerTransactionResponses(Long buyerId) {
+        List<Transaction> transactions = listBuyerTransactions(buyerId);
+        Set<Long> likedItemIds = findLikedItemIds(buyerId, transactions);
+        return transactions.stream()
+                .map(t -> new TransactionResponse(t, likedItemIds.contains(t.getItem().getId())))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<TransactionResponse> listSellerTransactionResponses(Long sellerId) {
+        List<Transaction> transactions = listSellerTransactions(sellerId);
+        Set<Long> likedItemIds = findLikedItemIds(sellerId, transactions);
+        return transactions.stream()
+                .map(t -> new TransactionResponse(t, likedItemIds.contains(t.getItem().getId())))
+                .collect(Collectors.toList());
+    }
+
     private Transaction findTransaction(Long transactionId) {
         return transactionRepository.findById(transactionId)
                 .orElseThrow(() -> new EntityNotFoundException("Transaction not found: " + transactionId));
+    }
+
+    private Set<Long> findLikedItemIds(Long userId, List<Transaction> transactions) {
+        List<Long> itemIds = transactions.stream()
+                .map(t -> t.getItem().getId())
+                .distinct()
+                .collect(Collectors.toList());
+        if (itemIds.isEmpty()) {
+            return Set.of();
+        }
+        return wishListRepository.findLikedItemIdsByUserId(userId, itemIds);
     }
 }

--- a/src/main/resources/static/chat-test.html
+++ b/src/main/resources/static/chat-test.html
@@ -1,0 +1,142 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chat WS Test</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    .row { margin-bottom: 10px; }
+    input, button { padding: 6px 8px; }
+    #log { white-space: pre-wrap; border: 1px solid #ccc; padding: 10px; height: 240px; overflow: auto; }
+  </style>
+</head>
+<body>
+  <h1>Chat WebSocket Test</h1>
+
+  <div class="row">
+    <label>Access Token</label>
+    <input id="token" style="width: 70%" placeholder="Bearer 없이 토큰만" />
+  </div>
+  <div class="row">
+    <label>Room ID</label>
+    <input id="roomId" value="10" />
+  </div>
+  <div class="row">
+    <button id="connectBtn">Connect</button>
+    <button id="subscribeBtn">Subscribe</button>
+    <button id="disconnectBtn">Disconnect</button>
+  </div>
+  <div class="row">
+    <input id="message" style="width: 70%" placeholder="message" />
+    <button id="sendBtn">Send</button>
+  </div>
+
+  <h3>Log</h3>
+  <div id="log"></div>
+
+  <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@7/bundles/stomp.umd.min.js"></script>
+  <script>
+    let client = null;
+    let subscription = null;
+
+    const logEl = document.getElementById('log');
+    const tokenEl = document.getElementById('token');
+    const roomIdEl = document.getElementById('roomId');
+    const messageEl = document.getElementById('message');
+
+    function log(msg) {
+      const now = new Date().toISOString();
+      logEl.textContent += `[${now}] ${msg}\n`;
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    document.getElementById('connectBtn').onclick = () => {
+      if (client && client.connected) {
+        log('Already connected');
+        return;
+      }
+      const sock = new SockJS('http://localhost:8080/ws/chat-sockjs');
+      const StompLib = window.StompJs || window.Stomp;
+      if (!StompLib) {
+        log('Stomp library not loaded');
+        return;
+      }
+      client = new StompLib.Client({
+        webSocketFactory: () => sock,
+        reconnectDelay: 0,
+        connectHeaders: {
+          Authorization: 'Bearer ' + tokenEl.value.trim()
+        },
+        onConnect: () => {
+          log('Connected');
+        },
+        onStompError: (frame) => {
+          log('STOMP error: ' + frame.headers['message']);
+        },
+        onWebSocketError: (err) => {
+          log('WS error: ' + err);
+        },
+        debug: (str) => {
+          // log(str);
+        }
+      });
+      client.activate();
+      log('Connecting...');
+    };
+
+    document.getElementById('subscribeBtn').onclick = () => {
+      if (!client || !client.connected) {
+        log('Not connected');
+        return;
+      }
+      const roomId = roomIdEl.value.trim();
+      if (!roomId) {
+        log('Room ID required');
+        return;
+      }
+      if (subscription) {
+        subscription.unsubscribe();
+        subscription = null;
+      }
+      const dest = `/sub/chat/rooms/${roomId}`;
+      subscription = client.subscribe(dest, (message) => {
+        log('Received: ' + message.body);
+      });
+      log('Subscribed to ' + dest);
+    };
+
+    document.getElementById('sendBtn').onclick = () => {
+      if (!client || !client.connected) {
+        log('Not connected');
+        return;
+      }
+      const roomId = roomIdEl.value.trim();
+      const content = messageEl.value;
+      if (!roomId || !content) {
+        log('Room ID and message required');
+        return;
+      }
+      client.publish({
+        destination: '/pub/chat/send',
+        body: JSON.stringify({ roomId: Number(roomId), content })
+      });
+      log('Sent: ' + content);
+      messageEl.value = '';
+    };
+
+    document.getElementById('disconnectBtn').onclick = () => {
+      if (subscription) {
+        subscription.unsubscribe();
+        subscription = null;
+      }
+      if (client) {
+        client.deactivate();
+        client = null;
+        log('Disconnected');
+      }
+    };
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## 요약
  - 1:1 채팅방 생성/목록 조회 API 추가
  - 채팅 메시지 조회/전송 API 추가
  - 채팅 메시지 DTO 및 응답 포맷 정리
  - WebSocket(STOMP) 채팅 전송/구독 추가

## 주요 변경
  - /api/chat/rooms (POST, GET)
  - /api/chat/rooms/{roomId}/messages (GET, POST)
  - /ws/chat, /ws/chat-sockjs
  - /pub/chat/send → /sub/chat/rooms/{roomId}


## 테스트
  - POST /api/chat/rooms (채팅방 생성)
  - GET /api/chat/rooms (채팅방 조회)
  - GET /api/chat/rooms/{roomId}/messages (채팅방 메시지 조회)
  - POST /api/chat/rooms/{roomId}/messages (채팅방 메시지 전송)
  - http://localhost:8080/chat-test.html 
  - 테스트 html을 통해 웹소켓 실시간 양방향 통신 테스트
