### PR TITLE
feat: 마이페이지 유저 정보 조회, 수정 기능 추가 / 내 게시글 조회, 찜 목록 조회 기능 추가 / 에러 처리 보강

### DIFF
--- a/src/main/java/com/swapandgo/sag/api/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/swapandgo/sag/api/error/GlobalExceptionHandler.java
@@ -1,0 +1,43 @@
+package com.swapandgo.sag.api.error;
+
+import com.swapandgo.sag.exception.ActiveTransactionException;
+import com.swapandgo.sag.exception.DuplicateUsernameException;
+import com.swapandgo.sag.exception.InvalidPasswordException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(InvalidPasswordException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidPassword(InvalidPasswordException ex) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", HttpStatus.BAD_REQUEST.value());
+        body.put("error", "Bad Request");
+        body.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(ActiveTransactionException.class)
+    public ResponseEntity<Map<String, Object>> handleActiveTransaction(ActiveTransactionException ex) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", HttpStatus.CONFLICT.value());
+        body.put("error", "Conflict");
+        body.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+    }
+
+    @ExceptionHandler(DuplicateUsernameException.class)
+    public ResponseEntity<Map<String, Object>> handleDuplicateUsername(DuplicateUsernameException ex) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", HttpStatus.CONFLICT.value());
+        body.put("error", "Conflict");
+        body.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+    }
+}

--- a/src/main/java/com/swapandgo/sag/api/mypage/MyPageController.java
+++ b/src/main/java/com/swapandgo/sag/api/mypage/MyPageController.java
@@ -1,0 +1,64 @@
+package com.swapandgo.sag.api.mypage;
+
+import com.swapandgo.sag.dto.mypage.MyItemResponse;
+import com.swapandgo.sag.dto.mypage.MyProfileResponse;
+import com.swapandgo.sag.dto.mypage.MyProfileUpdateRequest;
+import com.swapandgo.sag.dto.mypage.MyAccountDeleteRequest;
+import com.swapandgo.sag.dto.wishList.WishListItemResponse;
+import com.swapandgo.sag.security.user.CustomUserDetails;
+import com.swapandgo.sag.service.mypage.MyPageService;
+import com.swapandgo.sag.service.wishList.WishListService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/mypage")
+public class MyPageController {
+    private final WishListService wishListService;
+    private final MyPageService myPageService;
+
+    @GetMapping("/profile")
+    public ResponseEntity<MyProfileResponse> getMyProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        return ResponseEntity.ok(myPageService.getMyProfile(userId));
+    }
+
+    @PatchMapping("/profile")
+    public ResponseEntity<MyProfileResponse> updateMyProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody MyProfileUpdateRequest request) {
+        Long userId = userDetails.getUserId();
+        return ResponseEntity.ok(myPageService.updateMyProfile(userId, request));
+    }
+
+    @DeleteMapping("/profile")
+    public ResponseEntity<String> deleteMyProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody MyAccountDeleteRequest request) {
+        Long userId = userDetails.getUserId();
+        myPageService.deleteMyAccount(userId, request);
+        return ResponseEntity.ok("회원 탈퇴가 완료되었습니다.");
+    }
+
+    @GetMapping("/items")
+    public ResponseEntity<List<MyItemResponse>> listMyItems(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        List<MyItemResponse> responses = myPageService.listMyItems(userId);
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/wishlist")
+    public ResponseEntity<List<WishListItemResponse>> listMyWishList(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        List<WishListItemResponse> responses = wishListService.listMyWishList(userId);
+        return ResponseEntity.ok(responses);
+    }
+}

--- a/src/main/java/com/swapandgo/sag/dto/mypage/MyAccountDeleteRequest.java
+++ b/src/main/java/com/swapandgo/sag/dto/mypage/MyAccountDeleteRequest.java
@@ -1,0 +1,10 @@
+package com.swapandgo.sag.dto.mypage;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MyAccountDeleteRequest {
+    private String password;
+}

--- a/src/main/java/com/swapandgo/sag/dto/mypage/MyAddressResponse.java
+++ b/src/main/java/com/swapandgo/sag/dto/mypage/MyAddressResponse.java
@@ -1,0 +1,38 @@
+package com.swapandgo.sag.dto.mypage;
+
+import com.swapandgo.sag.domain.user.Address;
+import lombok.Getter;
+
+@Getter
+public class MyAddressResponse {
+    private final String fullAddress;
+    private final Double latitude;
+    private final Double longitude;
+    private final String country;
+    private final String region;
+    private final String district;
+    private final String street;
+    private final String zipcode;
+
+    public MyAddressResponse(Address address) {
+        if (address == null) {
+            this.fullAddress = null;
+            this.latitude = null;
+            this.longitude = null;
+            this.country = null;
+            this.region = null;
+            this.district = null;
+            this.street = null;
+            this.zipcode = null;
+            return;
+        }
+        this.fullAddress = address.getFullAddress();
+        this.latitude = address.getLatitude();
+        this.longitude = address.getLongitude();
+        this.country = address.getCountry();
+        this.region = address.getRegion();
+        this.district = address.getDistrict();
+        this.street = address.getStreet();
+        this.zipcode = address.getZipcode();
+    }
+}

--- a/src/main/java/com/swapandgo/sag/dto/mypage/MyItemResponse.java
+++ b/src/main/java/com/swapandgo/sag/dto/mypage/MyItemResponse.java
@@ -1,0 +1,32 @@
+package com.swapandgo.sag.dto.mypage;
+
+import com.swapandgo.sag.domain.item.Item;
+import com.swapandgo.sag.domain.item.ItemStatus;
+import com.swapandgo.sag.domain.item.ItemType;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+public class MyItemResponse {
+    private final Long itemId;
+    private final String title;
+    private final BigDecimal price;
+    private final String location;
+    private final String thumbnailUrl;
+    private final ItemStatus status;
+    private final ItemType itemType;
+    private final LocalDateTime createdAt;
+
+    public MyItemResponse(Item item) {
+        this.itemId = item.getId();
+        this.title = item.getTitle();
+        this.price = item.getPrice();
+        this.location = item.getLocation();
+        this.thumbnailUrl = item.getThumbnailUrl();
+        this.status = item.getStatus();
+        this.itemType = item.getType();
+        this.createdAt = item.getCreatedAt();
+    }
+}

--- a/src/main/java/com/swapandgo/sag/dto/mypage/MyProfileResponse.java
+++ b/src/main/java/com/swapandgo/sag/dto/mypage/MyProfileResponse.java
@@ -1,0 +1,19 @@
+package com.swapandgo.sag.dto.mypage;
+
+import com.swapandgo.sag.domain.user.User;
+import lombok.Getter;
+
+@Getter
+public class MyProfileResponse {
+    private final Long userId;
+    private final String email;
+    private final String username;
+    private final MyAddressResponse address;
+
+    public MyProfileResponse(User user) {
+        this.userId = user.getId();
+        this.email = user.getEmail();
+        this.username = user.getUsername();
+        this.address = new MyAddressResponse(user.getAddress());
+    }
+}

--- a/src/main/java/com/swapandgo/sag/dto/mypage/MyProfileUpdateRequest.java
+++ b/src/main/java/com/swapandgo/sag/dto/mypage/MyProfileUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.swapandgo.sag.dto.mypage;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MyProfileUpdateRequest {
+    private String username;
+    private String password;
+
+    private String fullAddress;
+    private Double latitude;
+    private Double longitude;
+    private String country;
+    private String region;
+    private String district;
+    private String street;
+    private String zipcode;
+}

--- a/src/main/java/com/swapandgo/sag/dto/wishList/WishListItemResponse.java
+++ b/src/main/java/com/swapandgo/sag/dto/wishList/WishListItemResponse.java
@@ -1,0 +1,31 @@
+package com.swapandgo.sag.dto.wishList;
+
+import com.swapandgo.sag.domain.WishList;
+import com.swapandgo.sag.domain.item.ItemStatus;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+public class WishListItemResponse {
+    private final Long itemId;
+    private final String itemTitle;
+    private final String itemThumbnailUrl;
+    private final BigDecimal itemPrice;
+    private final String itemLocation;
+    private final ItemStatus itemStatus;
+    private final boolean isLiked;
+    private final LocalDateTime itemCreatedAt;
+
+    public WishListItemResponse(WishList wishList) {
+        this.itemId = wishList.getItem().getId();
+        this.itemTitle = wishList.getItem().getTitle();
+        this.itemThumbnailUrl = wishList.getItem().getThumbnailUrl();
+        this.itemPrice = wishList.getItem().getPrice();
+        this.itemLocation = wishList.getItem().getLocation();
+        this.itemStatus = wishList.getItem().getStatus();
+        this.isLiked = true;
+        this.itemCreatedAt = wishList.getItem().getCreatedAt();
+    }
+}

--- a/src/main/java/com/swapandgo/sag/exception/ActiveTransactionException.java
+++ b/src/main/java/com/swapandgo/sag/exception/ActiveTransactionException.java
@@ -1,0 +1,7 @@
+package com.swapandgo.sag.exception;
+
+public class ActiveTransactionException extends RuntimeException {
+    public ActiveTransactionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/swapandgo/sag/exception/DuplicateUsernameException.java
+++ b/src/main/java/com/swapandgo/sag/exception/DuplicateUsernameException.java
@@ -1,0 +1,7 @@
+package com.swapandgo.sag.exception;
+
+public class DuplicateUsernameException extends RuntimeException {
+    public DuplicateUsernameException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/swapandgo/sag/exception/InvalidPasswordException.java
+++ b/src/main/java/com/swapandgo/sag/exception/InvalidPasswordException.java
@@ -1,0 +1,7 @@
+package com.swapandgo.sag.exception;
+
+public class InvalidPasswordException extends RuntimeException {
+    public InvalidPasswordException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/swapandgo/sag/repository/ItemRepository.java
+++ b/src/main/java/com/swapandgo/sag/repository/ItemRepository.java
@@ -3,5 +3,8 @@ package com.swapandgo.sag.repository;
 import com.swapandgo.sag.domain.item.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ItemRepository extends JpaRepository<Item, Long> {
+    List<Item> findAllByUserIdOrderByIdDesc(Long userId);
 }

--- a/src/main/java/com/swapandgo/sag/repository/TransactionRepository.java
+++ b/src/main/java/com/swapandgo/sag/repository/TransactionRepository.java
@@ -20,4 +20,10 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
     List<Transaction> findAllByBuyerIdOrderByIdDesc(Long buyerId);
 
     List<Transaction> findAllByItemUserIdOrderByIdDesc(Long sellerId);
+
+    @Query("SELECT COUNT(t) > 0 FROM Transaction t " +
+            "WHERE t.type = com.swapandgo.sag.domain.item.ItemType.RENTAL " +
+            "AND t.startAt <= :now AND t.endAt >= :now " +
+            "AND (t.buyer.id = :userId OR t.item.user.id = :userId)")
+    boolean existsActiveRentalForUser(@Param("userId") Long userId, @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/swapandgo/sag/repository/UserRepository.java
+++ b/src/main/java/com/swapandgo/sag/repository/UserRepository.java
@@ -9,5 +9,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
+    boolean existsByUsername(String username);
 
 }

--- a/src/main/java/com/swapandgo/sag/repository/WishListRepository.java
+++ b/src/main/java/com/swapandgo/sag/repository/WishListRepository.java
@@ -20,5 +20,6 @@ public interface WishListRepository extends JpaRepository<WishList, Long> {
 
     Optional<WishList> findWishListByItemIdAndUserId(Long itemId, Long userId);
     boolean existsByItemIdAndUserId(Long itemId, Long userId);
+    List<WishList> findAllByUserIdOrderByIdDesc(Long userId);
 
 }

--- a/src/main/java/com/swapandgo/sag/service/mypage/MyPageService.java
+++ b/src/main/java/com/swapandgo/sag/service/mypage/MyPageService.java
@@ -1,0 +1,111 @@
+package com.swapandgo.sag.service.mypage;
+
+import com.swapandgo.sag.domain.item.Item;
+import com.swapandgo.sag.domain.user.Address;
+import com.swapandgo.sag.domain.user.User;
+import com.swapandgo.sag.dto.mypage.MyAccountDeleteRequest;
+import com.swapandgo.sag.dto.mypage.MyItemResponse;
+import com.swapandgo.sag.dto.mypage.MyProfileResponse;
+import com.swapandgo.sag.dto.mypage.MyProfileUpdateRequest;
+import com.swapandgo.sag.exception.ActiveTransactionException;
+import com.swapandgo.sag.exception.DuplicateUsernameException;
+import com.swapandgo.sag.exception.InvalidPasswordException;
+import com.swapandgo.sag.repository.ItemRepository;
+import com.swapandgo.sag.repository.TransactionRepository;
+import com.swapandgo.sag.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MyPageService {
+    private final UserRepository userRepository;
+    private final ItemRepository itemRepository;
+    private final TransactionRepository transactionRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional(readOnly = true)
+    public MyProfileResponse getMyProfile(Long userId) {
+        User user = getUser(userId);
+        return new MyProfileResponse(user);
+    }
+
+    public MyProfileResponse updateMyProfile(Long userId, MyProfileUpdateRequest request) {
+        User user = getUser(userId);
+        if (request.getUsername() != null && !request.getUsername().isBlank()
+                && !request.getUsername().equals(user.getUsername())
+                && userRepository.existsByUsername(request.getUsername())) {
+            throw new DuplicateUsernameException("이미 사용 중인 닉네임입니다.");
+        }
+        Address newAddress = mergeAddress(user.getAddress(), request);
+        user.updateProfile(request.getUsername(), request.getPassword(), newAddress);
+        return new MyProfileResponse(user);
+    }
+
+    public void deleteMyAccount(Long userId, MyAccountDeleteRequest request) {
+        if (transactionRepository.existsActiveRentalForUser(userId, LocalDateTime.now())) {
+            throw new ActiveTransactionException("현재 진행 중인 대여 거래가 있어 탈퇴할 수 없습니다.");
+        }
+        User user = getUser(userId);
+        if (request == null || request.getPassword() == null || request.getPassword().isBlank()) {
+            throw new InvalidPasswordException("비밀번호를 입력해주세요.");
+        }
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new InvalidPasswordException("비밀번호가 일치하지 않습니다.");
+        }
+        userRepository.delete(user);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MyItemResponse> listMyItems(Long userId) {
+        List<Item> items = itemRepository.findAllByUserIdOrderByIdDesc(userId);
+        return items.stream().map(MyItemResponse::new).collect(Collectors.toList());
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found: " + userId));
+    }
+
+    private Address mergeAddress(Address current, MyProfileUpdateRequest request) {
+        boolean hasAny = request.getFullAddress() != null
+                || request.getLatitude() != null
+                || request.getLongitude() != null
+                || request.getCountry() != null
+                || request.getRegion() != null
+                || request.getDistrict() != null
+                || request.getStreet() != null
+                || request.getZipcode() != null;
+
+        if (!hasAny && current == null) {
+            return null;
+        }
+
+        String fullAddress = request.getFullAddress() != null ? request.getFullAddress()
+                : current != null ? current.getFullAddress() : null;
+        Double latitude = request.getLatitude() != null ? request.getLatitude()
+                : current != null ? current.getLatitude() : null;
+        Double longitude = request.getLongitude() != null ? request.getLongitude()
+                : current != null ? current.getLongitude() : null;
+        String country = request.getCountry() != null ? request.getCountry()
+                : current != null ? current.getCountry() : null;
+        String region = request.getRegion() != null ? request.getRegion()
+                : current != null ? current.getRegion() : null;
+        String district = request.getDistrict() != null ? request.getDistrict()
+                : current != null ? current.getDistrict() : null;
+        String street = request.getStreet() != null ? request.getStreet()
+                : current != null ? current.getStreet() : null;
+        String zipcode = request.getZipcode() != null ? request.getZipcode()
+                : current != null ? current.getZipcode() : null;
+
+        return new Address(fullAddress, latitude, longitude, country, region, district, street, zipcode);
+    }
+}

--- a/src/main/java/com/swapandgo/sag/service/wishList/WishListService.java
+++ b/src/main/java/com/swapandgo/sag/service/wishList/WishListService.java
@@ -3,6 +3,7 @@ package com.swapandgo.sag.service.wishList;
 import com.swapandgo.sag.domain.WishList;
 import com.swapandgo.sag.domain.item.Item;
 import com.swapandgo.sag.domain.user.User;
+import com.swapandgo.sag.dto.wishList.WishListItemResponse;
 import com.swapandgo.sag.dto.wishList.WishListResponse;
 import com.swapandgo.sag.repository.ItemRepository;
 import com.swapandgo.sag.repository.UserRepository;
@@ -13,6 +14,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -42,6 +45,13 @@ public class WishListService {
         }
 
         return new WishListResponse(itemId, isLiked);
+    }
+
+    @Transactional(readOnly = true)
+    public List<WishListItemResponse> listMyWishList(Long userId) {
+        return wishListRepository.findAllByUserIdOrderByIdDesc(userId).stream()
+                .map(WishListItemResponse::new)
+                .collect(Collectors.toList());
     }
 
 }


### PR DESCRIPTION
  ## 요약
  - 마이페이지 프로필 조회/수정/탈퇴 API 추가
  - 내가 올린 상품 목록 조회 API 추가
  - 찜 목록 조회 API 추가
  - 마이페이지 관련 에러 응답(비밀번호/거래중/닉네임 중복) 추가

  ## API
  - GET /api/mypage/profile
  - PATCH /api/mypage/profile
  - DELETE /api/mypage/profile (비밀번호 확인)
  - GET /api/mypage/items
  - GET /api/mypage/wishlist

  ## 에러 응답
  - 회원 탈퇴 시도 시 비밀번호 확인, 비밀번호 불일치/미입력: 400
  - 회원 탈퇴 진행 중 대여 거래 있음: 409
  - 회원 정보 수정 시 닉네임 중복: 409