### PR TITLE
refactor: 조기반납 응답 필드명 통일 및 거래요청 응답 정리

### DIFF
--- a/src/main/java/com/swapandgo/sag/api/tradeoffer/TradeOfferController.java
+++ b/src/main/java/com/swapandgo/sag/api/tradeoffer/TradeOfferController.java
@@ -66,7 +66,9 @@ public class TradeOfferController {
         }
         if (status == TradeOfferStatus.ACCEPTED) {
             TradeOfferAcceptResult result = tradeOfferService.acceptOffer(userId, tradeOfferId);
-            TradeOfferSimpleResponse response = new TradeOfferSimpleResponse(result.getTradeOffer());
+            TradeOfferSimpleResponse response = new TradeOfferSimpleResponse(
+                    result.getTradeOffer(), result.getTransactionId()
+            );
             return ResponseEntity.ok(response);
         }
         if (status == TradeOfferStatus.REJECTED) {

--- a/src/main/java/com/swapandgo/sag/api/tradeoffer/TradeOfferController.java
+++ b/src/main/java/com/swapandgo/sag/api/tradeoffer/TradeOfferController.java
@@ -4,6 +4,7 @@ import com.swapandgo.sag.domain.item.ItemType;
 import com.swapandgo.sag.domain.tradeoffer.TradeOfferStatus;
 import com.swapandgo.sag.dto.tradeoffer.TradeOfferCreateRequest;
 import com.swapandgo.sag.dto.tradeoffer.TradeOfferResponse;
+import com.swapandgo.sag.dto.tradeoffer.TradeOfferSimpleResponse;
 import com.swapandgo.sag.dto.tradeoffer.TradeOfferStatusUpdateRequest;
 import com.swapandgo.sag.security.user.CustomUserDetails;
 import com.swapandgo.sag.service.tradeoffer.TradeOfferAcceptResult;
@@ -29,47 +30,47 @@ public class TradeOfferController {
     private final TradeOfferService tradeOfferService;
 
     @PostMapping("/api/tradeoffers/resale")
-    public ResponseEntity<TradeOfferResponse> createResaleTradeOffer(
+    public ResponseEntity<TradeOfferSimpleResponse> createResaleTradeOffer(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid TradeOfferCreateRequest request) {
         Long userId = userDetails.getUserId();
-        TradeOfferResponse response = new TradeOfferResponse(
+        TradeOfferSimpleResponse response = new TradeOfferSimpleResponse(
                 tradeOfferService.createOffer(userId, request, ItemType.RESALE)
         );
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/api/tradeoffers/rental")
-    public ResponseEntity<TradeOfferResponse> createRentalTradeOffer(
+    public ResponseEntity<TradeOfferSimpleResponse> createRentalTradeOffer(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid TradeOfferCreateRequest request) {
         Long userId = userDetails.getUserId();
-        TradeOfferResponse response = new TradeOfferResponse(
+        TradeOfferSimpleResponse response = new TradeOfferSimpleResponse(
                 tradeOfferService.createOffer(userId, request, ItemType.RENTAL)
         );
         return ResponseEntity.ok(response);
     }
 
     @PatchMapping("/api/tradeoffers/{tradeOfferId}")
-    public ResponseEntity<TradeOfferResponse> updateTradeOfferStatus(
+    public ResponseEntity<TradeOfferSimpleResponse> updateTradeOfferStatus(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long tradeOfferId,
             @RequestBody @Valid TradeOfferStatusUpdateRequest request) {
         Long userId = userDetails.getUserId();
         TradeOfferStatus status = request.getStatus();
         if (status == TradeOfferStatus.CANCELED) {
-            TradeOfferResponse response = new TradeOfferResponse(
+            TradeOfferSimpleResponse response = new TradeOfferSimpleResponse(
                     tradeOfferService.cancelOffer(userId, tradeOfferId)
             );
             return ResponseEntity.ok(response);
         }
         if (status == TradeOfferStatus.ACCEPTED) {
             TradeOfferAcceptResult result = tradeOfferService.acceptOffer(userId, tradeOfferId);
-            TradeOfferResponse response = new TradeOfferResponse(result.getTradeOffer(), result.getTransactionId());
+            TradeOfferSimpleResponse response = new TradeOfferSimpleResponse(result.getTradeOffer());
             return ResponseEntity.ok(response);
         }
         if (status == TradeOfferStatus.REJECTED) {
-            TradeOfferResponse response = new TradeOfferResponse(
+            TradeOfferSimpleResponse response = new TradeOfferSimpleResponse(
                     tradeOfferService.rejectOffer(userId, tradeOfferId)
             );
             return ResponseEntity.ok(response);

--- a/src/main/java/com/swapandgo/sag/dto/mypage/MyAddressResponse.java
+++ b/src/main/java/com/swapandgo/sag/dto/mypage/MyAddressResponse.java
@@ -1,38 +1,16 @@
 package com.swapandgo.sag.dto.mypage;
 
-import com.swapandgo.sag.domain.user.Address;
 import lombok.Getter;
 
 @Getter
 public class MyAddressResponse {
-    private final String fullAddress;
-    private final Double latitude;
-    private final Double longitude;
     private final String country;
     private final String region;
-    private final String district;
     private final String street;
-    private final String zipcode;
 
-    public MyAddressResponse(Address address) {
-        if (address == null) {
-            this.fullAddress = null;
-            this.latitude = null;
-            this.longitude = null;
-            this.country = null;
-            this.region = null;
-            this.district = null;
-            this.street = null;
-            this.zipcode = null;
-            return;
-        }
-        this.fullAddress = address.getFullAddress();
-        this.latitude = address.getLatitude();
-        this.longitude = address.getLongitude();
-        this.country = address.getCountry();
-        this.region = address.getRegion();
-        this.district = address.getDistrict();
-        this.street = address.getStreet();
-        this.zipcode = address.getZipcode();
+    public MyAddressResponse(String country, String region, String street) {
+        this.country = country;
+        this.region = region;
+        this.street = street;
     }
 }

--- a/src/main/java/com/swapandgo/sag/dto/mypage/MyProfileResponse.java
+++ b/src/main/java/com/swapandgo/sag/dto/mypage/MyProfileResponse.java
@@ -14,6 +14,14 @@ public class MyProfileResponse {
         this.userId = user.getId();
         this.email = user.getEmail();
         this.username = user.getUsername();
-        this.address = new MyAddressResponse(user.getAddress());
+        if (user.getAddress() == null) {
+            this.address = new MyAddressResponse(null, null, null);
+        } else {
+            this.address = new MyAddressResponse(
+                    user.getAddress().getCountry(),
+                    user.getAddress().getRegion(),
+                    user.getAddress().getStreet()
+            );
+        }
     }
 }

--- a/src/main/java/com/swapandgo/sag/dto/mypage/MyProfileUpdateRequest.java
+++ b/src/main/java/com/swapandgo/sag/dto/mypage/MyProfileUpdateRequest.java
@@ -9,12 +9,7 @@ public class MyProfileUpdateRequest {
     private String username;
     private String password;
 
-    private String fullAddress;
-    private Double latitude;
-    private Double longitude;
     private String country;
     private String region;
-    private String district;
     private String street;
-    private String zipcode;
 }

--- a/src/main/java/com/swapandgo/sag/dto/tradeoffer/TradeOfferSimpleResponse.java
+++ b/src/main/java/com/swapandgo/sag/dto/tradeoffer/TradeOfferSimpleResponse.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @Getter
 @JsonPropertyOrder({
         "tradeOfferId",
+        "transactionId",
         "itemId",
         "requesterId",
         "status",
@@ -19,6 +20,7 @@ import java.time.LocalDateTime;
 })
 public class TradeOfferSimpleResponse {
     private final Long tradeOfferId;
+    private final Long transactionId;
     private final Long itemId;
     private final Long requesterId;
     private final TradeOfferStatus status;
@@ -28,6 +30,18 @@ public class TradeOfferSimpleResponse {
 
     public TradeOfferSimpleResponse(TradeOffer tradeOffer) {
         this.tradeOfferId = tradeOffer.getId();
+        this.transactionId = null;
+        this.itemId = tradeOffer.getItem().getId();
+        this.requesterId = tradeOffer.getRequester().getId();
+        this.status = tradeOffer.getStatus();
+        this.createdAt = tradeOffer.getCreatedAt();
+        this.startAt = tradeOffer.getStartAt();
+        this.endAt = tradeOffer.getEndAt();
+    }
+
+    public TradeOfferSimpleResponse(TradeOffer tradeOffer, Long transactionId) {
+        this.tradeOfferId = tradeOffer.getId();
+        this.transactionId = transactionId;
         this.itemId = tradeOffer.getItem().getId();
         this.requesterId = tradeOffer.getRequester().getId();
         this.status = tradeOffer.getStatus();

--- a/src/main/java/com/swapandgo/sag/dto/tradeoffer/TradeOfferSimpleResponse.java
+++ b/src/main/java/com/swapandgo/sag/dto/tradeoffer/TradeOfferSimpleResponse.java
@@ -1,0 +1,38 @@
+package com.swapandgo.sag.dto.tradeoffer;
+
+import com.swapandgo.sag.domain.tradeoffer.TradeOffer;
+import com.swapandgo.sag.domain.tradeoffer.TradeOfferStatus;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@JsonPropertyOrder({
+        "tradeOfferId",
+        "itemId",
+        "requesterId",
+        "status",
+        "createdAt",
+        "startAt",
+        "endAt"
+})
+public class TradeOfferSimpleResponse {
+    private final Long tradeOfferId;
+    private final Long itemId;
+    private final Long requesterId;
+    private final TradeOfferStatus status;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime startAt;
+    private final LocalDateTime endAt;
+
+    public TradeOfferSimpleResponse(TradeOffer tradeOffer) {
+        this.tradeOfferId = tradeOffer.getId();
+        this.itemId = tradeOffer.getItem().getId();
+        this.requesterId = tradeOffer.getRequester().getId();
+        this.status = tradeOffer.getStatus();
+        this.createdAt = tradeOffer.getCreatedAt();
+        this.startAt = tradeOffer.getStartAt();
+        this.endAt = tradeOffer.getEndAt();
+    }
+}

--- a/src/main/java/com/swapandgo/sag/dto/transaction/EarlyReturnResponse.java
+++ b/src/main/java/com/swapandgo/sag/dto/transaction/EarlyReturnResponse.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
         "requesterId",
         "status",
         "requestedAt",
-        "earlyReturnAt",
+        "newEndAt",
         "currentEndAt"
 })
 public class EarlyReturnResponse {
@@ -23,7 +23,7 @@ public class EarlyReturnResponse {
     private final Long requesterId;
     private final EarlyReturnStatus status;
     private final LocalDateTime requestedAt;
-    private final LocalDateTime earlyReturnAt;
+    private final LocalDateTime newEndAt;
     private final LocalDateTime currentEndAt;
 
     public EarlyReturnResponse(Transaction transaction) {
@@ -32,7 +32,7 @@ public class EarlyReturnResponse {
         this.requesterId = transaction.getBuyer().getId();
         this.status = transaction.getEarlyReturnStatus();
         this.requestedAt = transaction.getEarlyReturnRequestedAt();
-        this.earlyReturnAt = transaction.getEarlyReturnAt();
+        this.newEndAt = transaction.getEarlyReturnAt();
         this.currentEndAt = transaction.getEndAt();
     }
 }

--- a/src/main/java/com/swapandgo/sag/dto/transaction/TransactionResponse.java
+++ b/src/main/java/com/swapandgo/sag/dto/transaction/TransactionResponse.java
@@ -25,6 +25,7 @@ public class TransactionResponse {
     private final ItemStatus itemStatus;
     private final LocalDateTime startAt;
     private final LocalDateTime endAt;
+    private final LocalDateTime earlyReturnAt;
     private final EarlyReturnStatus earlyReturnStatus;
     private final LocalDateTime createdAt;
 
@@ -44,6 +45,7 @@ public class TransactionResponse {
         this.itemStatus = transaction.getItem().getStatus();
         this.startAt = transaction.getStartAt();
         this.endAt = transaction.getEndAt();
+        this.earlyReturnAt = transaction.getEarlyReturnAt();
         this.earlyReturnStatus = transaction.getEarlyReturnStatus();
         this.createdAt = transaction.getCreatedAt();
     }
@@ -64,6 +66,7 @@ public class TransactionResponse {
         this.itemStatus = transaction.getItem().getStatus();
         this.startAt = transaction.getStartAt();
         this.endAt = transaction.getEndAt();
+        this.earlyReturnAt = transaction.getEarlyReturnAt();
         this.earlyReturnStatus = transaction.getEarlyReturnStatus();
         this.createdAt = transaction.getCreatedAt();
     }

--- a/src/main/java/com/swapandgo/sag/dto/transaction/TransactionResponse.java
+++ b/src/main/java/com/swapandgo/sag/dto/transaction/TransactionResponse.java
@@ -25,7 +25,7 @@ public class TransactionResponse {
     private final ItemStatus itemStatus;
     private final LocalDateTime startAt;
     private final LocalDateTime endAt;
-    private final LocalDateTime earlyReturnAt;
+    private final LocalDateTime newEndAt;
     private final EarlyReturnStatus earlyReturnStatus;
     private final LocalDateTime createdAt;
 
@@ -45,7 +45,7 @@ public class TransactionResponse {
         this.itemStatus = transaction.getItem().getStatus();
         this.startAt = transaction.getStartAt();
         this.endAt = transaction.getEndAt();
-        this.earlyReturnAt = transaction.getEarlyReturnAt();
+        this.newEndAt = transaction.getEarlyReturnAt();
         this.earlyReturnStatus = transaction.getEarlyReturnStatus();
         this.createdAt = transaction.getCreatedAt();
     }
@@ -66,7 +66,7 @@ public class TransactionResponse {
         this.itemStatus = transaction.getItem().getStatus();
         this.startAt = transaction.getStartAt();
         this.endAt = transaction.getEndAt();
-        this.earlyReturnAt = transaction.getEarlyReturnAt();
+        this.newEndAt = transaction.getEarlyReturnAt();
         this.earlyReturnStatus = transaction.getEarlyReturnStatus();
         this.createdAt = transaction.getCreatedAt();
     }

--- a/src/main/java/com/swapandgo/sag/service/mypage/MyPageService.java
+++ b/src/main/java/com/swapandgo/sag/service/mypage/MyPageService.java
@@ -76,36 +76,21 @@ public class MyPageService {
     }
 
     private Address mergeAddress(Address current, MyProfileUpdateRequest request) {
-        boolean hasAny = request.getFullAddress() != null
-                || request.getLatitude() != null
-                || request.getLongitude() != null
-                || request.getCountry() != null
+        boolean hasAny = request.getCountry() != null
                 || request.getRegion() != null
-                || request.getDistrict() != null
-                || request.getStreet() != null
-                || request.getZipcode() != null;
+                || request.getStreet() != null;
 
         if (!hasAny && current == null) {
             return null;
         }
 
-        String fullAddress = request.getFullAddress() != null ? request.getFullAddress()
-                : current != null ? current.getFullAddress() : null;
-        Double latitude = request.getLatitude() != null ? request.getLatitude()
-                : current != null ? current.getLatitude() : null;
-        Double longitude = request.getLongitude() != null ? request.getLongitude()
-                : current != null ? current.getLongitude() : null;
         String country = request.getCountry() != null ? request.getCountry()
                 : current != null ? current.getCountry() : null;
         String region = request.getRegion() != null ? request.getRegion()
                 : current != null ? current.getRegion() : null;
-        String district = request.getDistrict() != null ? request.getDistrict()
-                : current != null ? current.getDistrict() : null;
         String street = request.getStreet() != null ? request.getStreet()
                 : current != null ? current.getStreet() : null;
-        String zipcode = request.getZipcode() != null ? request.getZipcode()
-                : current != null ? current.getZipcode() : null;
 
-        return new Address(fullAddress, latitude, longitude, country, region, district, street, zipcode);
+        return new Address(country, region, street);
     }
 }


### PR DESCRIPTION
  ## 요약
  - 조기반납 응답 필드명 newEndAt으로 통일
  - 거래요청 POST/PATCH 응답을 간소화하고 수락 시 transactionId 유지

  ## 변경사항
  - EarlyReturnResponse / TransactionResponse 필드명 통일(earlyReturnAt → newEndAt)
  - TradeOfferSimpleResponse dto 도입 및 POST/PATCH 응답 단순화

  ## 테스트
  - POST /api/tradeoffers/resale
  - POST /api/tradeoffers/rental
  - PATCH /api/tradeoffers/{id} (ACCEPTED)
  - POST /api/transactions/{id}/early-return
  - GET /api/transactions/buyer
